### PR TITLE
改进机型检测，使之能检测到刷入了 GAPPS 的 WSA

### DIFF
--- a/APKInstaller/APKInstaller/Pages/InstallPage.xaml.cs
+++ b/APKInstaller/APKInstaller/Pages/InstallPage.xaml.cs
@@ -194,10 +194,13 @@ namespace APKInstaller.Pages
         private bool CheckDevice()
         {
             List<DeviceData> devices = new AdvancedAdbClient().GetDevices();
+            AdvancedAdbClient client = new();
+            ConsoleOutputReceiver receiver = new ConsoleOutputReceiver();
             if (devices.Count <= 0) { return false; }
             foreach (DeviceData device in devices)
             {
-                if(device.Model.Contains("Subsystem_for_Android_TM_"))
+                client.ExecuteRemoteCommand("getprop ro.product.odm.brand", device, receiver);
+                if (receiver.ToString().Contains("Windows"))
                 {
                     this.device = device ?? this.device;
                     return true;


### PR DESCRIPTION
刷入了 GAPPS 的 WSA 机型信息被修改成了 Pixel 5，原来的检测方法没有办法检测到 WSA，用 getprop 发现 ro.product.odm.brand 没有被修改，信息为 Windows，可以用来检测，所以将检测方法改成了 getprop，修改后就可以正常检测到了
![微信截图_20211024203710](https://user-images.githubusercontent.com/15278036/138594495-7daf2108-9690-494c-a17c-cf0a0d2066fb.png)
![微信截图_20211024203615](https://user-images.githubusercontent.com/15278036/138594496-6d0b5452-b899-4826-ba35-91b2583c2b08.png)


