### PR TITLE
修复了无法检测到 MagiskOnWSA 项目构建的 WSA 问题

### DIFF
--- a/APKInstaller/APKInstaller/Pages/InstallPage.xaml.cs
+++ b/APKInstaller/APKInstaller/Pages/InstallPage.xaml.cs
@@ -342,8 +342,8 @@ namespace APKInstaller.Pages
                 if(device == null) { continue; }
                 if (wsaonly)
                 {
-                    client.ExecuteRemoteCommand("getprop ro.product.odm.brand", device, receiver);
-                    if (receiver.ToString().Contains("Windows"))
+                    client.ExecuteRemoteCommand("getprop ro.boot.hardware", device, receiver);
+                    if (receiver.ToString().Contains("windows"))
                     {
                         this.device = device ?? this.device;
                         return true;


### PR DESCRIPTION
更改检测 prop 为 ro.boot.hardware （与SOC有关，高通手机返回值为 qcom，WSA 为 windows_$(arch)，它并不由 prop 定义，而是由 init 进程在系统启动时从固件或内核参数获取，所以不必担心 Magisk 和 GAPPS 对 prop 的修改引起识别异常，除非有人故意去搞内核），使之能正常检测到刷入了 Magisk 和 GAPPS 的 WSA